### PR TITLE
ajout de git clone dans le doc

### DIFF
--- a/Commandes_de_base.md
+++ b/Commandes_de_base.md
@@ -3,6 +3,11 @@
 git init
 ```
 
+# Cloner le dépôt
+```bash
+git clone git@github.com:theoc0702/Workflow.git
+```
+
 # Vérifier l’état
 ```bash
 git status


### PR DESCRIPTION
Ajout d'une section pour cloner le repository avec `git clone` dans le fichier **Commandes_de_base.md**